### PR TITLE
feature: animate pointer on each slice boundary during spin

### DIFF
--- a/app/src/main/java/com/thejiltedalchemist/lunchroulette/MainActivity.kt
+++ b/app/src/main/java/com/thejiltedalchemist/lunchroulette/MainActivity.kt
@@ -3,6 +3,8 @@ package com.thejiltedalchemist.lunchroulette
 import android.content.Intent
 import android.os.Bundle
 import android.os.CountDownTimer
+import android.view.View
+import android.view.animation.OvershootInterpolator
 import android.widget.Button
 import androidx.appcompat.app.AppCompatActivity
 import com.thejiltedalchemist.lunchroulette.databinding.ActivityMainBinding
@@ -49,6 +51,7 @@ class MainActivity : AppCompatActivity() {
     private fun pressToSpin(button: Button) {
         button.setOnClickListener {
             val ivWheel = activityMainBinding.rouletteWheel
+            val ivTarget = activityMainBinding.ivTarget
             val foodCount = foodList.size
             val spinIndex = Random.nextInt(foodCount)
             val winner = foodList[spinIndex]
@@ -63,9 +66,18 @@ class MainActivity : AppCompatActivity() {
             val spinDuration = (360 * SPIN_ROTATIONS * SPIN_INTERVAL_MS) / SPIN_SPEED.toLong()
             ivWheel.rotation = finalRotation + 360f * SPIN_ROTATIONS
 
+            var totalAngleTurned = 0f
+            var prevBoundaryCount = 0
+
             object : CountDownTimer(spinDuration, SPIN_INTERVAL_MS) {
                 override fun onTick(millisUntilFinished: Long) {
                     ivWheel.rotation -= SPIN_SPEED
+                    totalAngleTurned += SPIN_SPEED
+                    val newBoundaryCount = (totalAngleTurned / arcAngle).toInt()
+                    if (newBoundaryCount != prevBoundaryCount) {
+                        prevBoundaryCount = newBoundaryCount
+                        tickPointer(ivTarget)
+                    }
                 }
 
                 override fun onFinish() {
@@ -75,5 +87,19 @@ class MainActivity : AppCompatActivity() {
                 }
             }.start()
         }
+    }
+
+    // Pivots the pointer from its pin point (top-centre) so the tip swings in the
+    // direction the wheel is travelling, then springs back with a slight overshoot.
+    private fun tickPointer(view: View) {
+        view.pivotX = view.width / 2f
+        view.pivotY = 0f
+        view.animate().cancel()
+        view.rotation = -18f
+        view.animate()
+            .rotation(0f)
+            .setDuration(140)
+            .setInterpolator(OvershootInterpolator(3f))
+            .start()
     }
 }


### PR DESCRIPTION
Adds a clicker-style animation to the pointer arrow each time a slice boundary passes under it during a spin.

## Changes
- Track `totalAngleTurned` in the `CountDownTimer` tick loop
- Detect slice boundary crossings by comparing `(totalAngleTurned / arcAngle).toInt()` each tick
- `tickPointer()` pivots `ivTarget` from its top-centre pin, snaps the tip 18° in the direction of travel, then springs back with `OvershootInterpolator(3f)` for a satisfying bounce
- No layout changes — works with the existing `ivTarget` ImageView

---
_Generated by [Claude Code](https://claude.ai/code/session_01CMSARgRyKBg1wrtrfoVNcc)_