### PR TITLE
feature: expand wheel palette from 3 to 8 curated colours

### DIFF
--- a/app/src/main/java/com/thejiltedalchemist/lunchroulette/RouletteView.kt
+++ b/app/src/main/java/com/thejiltedalchemist/lunchroulette/RouletteView.kt
@@ -24,19 +24,27 @@ class RouletteView(context: Context,attrs: AttributeSet) : View(context, attrs) 
     private var arcAngle = 0F
 
     private val textColor = resources.getColor(R.color.colorAccent)
-    private var colorDark = resources.getColor(R.color.colorPrimaryDark)
-    private var colorLight = resources.getColor(R.color.colorPrimary)
-    private var colorAccent = resources.getColor(R.color.design_default_color_secondary_variant)
+    private val colorDark = resources.getColor(R.color.colorPrimaryDark)
+    private val colorLight = resources.getColor(R.color.colorPrimary)
 
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
         super.onMeasure(widthMeasureSpec, heightMeasureSpec)
-        val width = measuredWidth.coerceAtMost(measuredHeight) //Math.min
+        val width = measuredWidth.coerceAtMost(measuredHeight)
         padding = if (paddingLeft == 0) 10f else paddingLeft.toFloat()
         radius = width - (padding * 2)
         setMeasuredDimension(width, width)
     }
 
-    private val sliceColors = listOf(colorDark, colorLight, colorAccent)
+    private val sliceColors = listOf(
+        resources.getColor(R.color.wheel_slice_1),
+        resources.getColor(R.color.wheel_slice_2),
+        resources.getColor(R.color.wheel_slice_3),
+        resources.getColor(R.color.wheel_slice_4),
+        resources.getColor(R.color.wheel_slice_5),
+        resources.getColor(R.color.wheel_slice_6),
+        resources.getColor(R.color.wheel_slice_7),
+        resources.getColor(R.color.wheel_slice_8),
+    )
 
     override fun onDraw(canvas: Canvas) {
         super.onDraw(canvas)
@@ -57,16 +65,16 @@ class RouletteView(context: Context,attrs: AttributeSet) : View(context, attrs) 
         drawCenter(canvas)
     }
 
-    // For the last slice, pick whichever color is neither the first slice's color
-    // (wrap-around) nor the previous slice's color (adjacent). With 3 colors there
-    // is always exactly one such choice.
+    // For the last slice, pick whichever palette entry conflicts with neither the first
+    // slice (wrap-around adjacency) nor the previous slice (direct adjacency).
     private fun colorForSlice(index: Int, total: Int): Int {
-        var colorIndex = index % 3
+        val n = sliceColors.size
+        var colorIndex = index % n
         if (index == total - 1 && total > 1) {
-            val firstColorIndex = 0  // first slice is always 0 % 3
-            val prevColorIndex = (total - 2) % 3
+            val firstColorIndex = 0
+            val prevColorIndex = (total - 2) % n
             if (colorIndex == firstColorIndex || colorIndex == prevColorIndex) {
-                colorIndex = (0..2).first { it != firstColorIndex && it != prevColorIndex }
+                colorIndex = (0 until n).first { it != firstColorIndex && it != prevColorIndex }
             }
         }
         return sliceColors[colorIndex]

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -3,4 +3,14 @@
     <color name="colorPrimary">#5a7e8c</color>
     <color name="colorPrimaryDark">#3C535C</color>
     <color name="colorAccent">#ccd7dc</color>
+
+    <!-- Wheel slice palette — 8 colours in the blue-grey/teal family -->
+    <color name="wheel_slice_1">#3C535C</color>  <!-- dark teal-grey -->
+    <color name="wheel_slice_2">#5a7e8c</color>  <!-- medium teal -->
+    <color name="wheel_slice_3">#7fa3b0</color>  <!-- light teal -->
+    <color name="wheel_slice_4">#2d4a55</color>  <!-- deep navy-teal -->
+    <color name="wheel_slice_5">#8b9e6a</color>  <!-- muted olive -->
+    <color name="wheel_slice_6">#c4a882</color>  <!-- warm sand -->
+    <color name="wheel_slice_7">#4a6b5c</color>  <!-- forest teal -->
+    <color name="wheel_slice_8">#6b7fa0</color>  <!-- dusty slate blue -->
 </resources>


### PR DESCRIPTION
Expands the wheel slice palette from 3 to 8 colours, all within the blue-grey/teal family with complementary accents.

## Changes
- Add `wheel_slice_1..8` in `colors.xml` — dark teal-grey, medium teal, light teal, deep navy-teal, muted olive, warm sand, forest teal, dusty slate blue
- `RouletteView.sliceColors` now loads all 8 entries
- `colorForSlice()` generalised to work with any palette size — wrap-around adjacency guard still applies

---
_Generated by [Claude Code](https://claude.ai/code/session_01CMSARgRyKBg1wrtrfoVNcc)_