### PR TITLE
chore: update Gradle, Kotlin, AGP — initial SDK migration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,44 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build & Run Commands
+
+```bash
+# Build debug APK
+./gradlew assembleDebug
+
+# Install on connected device/emulator
+./gradlew installDebug
+
+# Run unit tests (JVM, no device needed)
+./gradlew test
+
+# Run a single unit test class
+./gradlew test --tests "com.thejiltedalchemist.lunchroulette.ExampleUnitTest"
+
+# Run instrumented tests (requires connected device or emulator)
+./gradlew connectedAndroidTest
+
+# Full build with lint
+./gradlew build
+```
+
+## Architecture Overview
+
+Single-module Android app (Kotlin, minSdk 26, targetSdk 34) with two activities and a custom view:
+
+**MainActivity** — entry point. Loads restaurants from SQLite on `onCreate`, renders the `RouletteView`, and drives the spin animation via `CountDownTimer`. The winner is determined *before* the animation starts (the wheel spins to land on a pre-chosen index).
+
+**RestaurantsListActivity** — CRUD list screen. Uses a `RecyclerView` with `RestaurantAdapter`. Swipe-to-delete is handled by `SwipeToDeleteCallback` (extends `ItemTouchHelper.SimpleCallback`); deleted items are held in memory and can be restored via a Snackbar undo action.
+
+**RouletteView** — custom `View` that draws pie-slice arcs with `Canvas.drawArc` and text along each arc's path. It alternates three colors (`colorPrimary`, `colorPrimaryDark`, `design_default_color_secondary_variant`). Call `addRouletteItems(list)` to repopulate and trigger a redraw.
+
+**Data layer** — `RestaurantsDBHelper` (extends `SQLiteOpenHelper`) wraps a single `restaurants` table with a `name TEXT PRIMARY KEY` column. `DBContract.RestaurantsEntry` defines the table/column constants. `RestaurantsModel` is a plain `data class(val name: String)`. Note: the schema also declares an `address` column in `SQL_CREATE_ENTRIES`, but `RestaurantsModel` only stores `name` — `address` is unused.
+
+**View binding** is enabled project-wide (`viewBinding = true`). Layouts: `activity_main.xml` (main screen), `list_page.xml` (list screen), `list_item_restaurant.xml` (row).
+
+## Known Issues / TODOs
+
+- `onUpgrade` in `RestaurantsDBHelper` calls `onCreate` without dropping the old table — increment `DATABASE_VERSION` when changing the schema and add a proper migration.
+- The `address` column exists in the DB schema but is never populated or read.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,11 @@ Single-module Android app (Kotlin, minSdk 26, targetSdk 34) with two activities 
 
 **View binding** is enabled project-wide (`viewBinding = true`). Layouts: `activity_main.xml` (main screen), `list_page.xml` (list screen), `list_item_restaurant.xml` (row).
 
+## Git Workflow
+
+- Branch prefixes: `feature/`, `bug/`, `chore/` — always follow this convention.
+- Never merge into `main` without explicit instruction.
+
 ## Known Issues / TODOs
 
 - `onUpgrade` in `RestaurantsDBHelper` calls `onCreate` without dropping the old table — increment `DATABASE_VERSION` when changing the schema and add a proper migration.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,16 +6,11 @@ apply plugin: 'kotlin-parcelize'
 android {
     compileSdkVersion 35
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_21
-        targetCompatibility = JavaVersion.VERSION_21
-    }
-    java {
-        toolchain {
-            languageVersion.set(JavaLanguageVersion.of(21))
-        }
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = '21'
+        jvmTarget = '17'
     }
     defaultConfig {
         applicationId "com.thejiltedalchemist.lunchroulette"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-parcelize'
 
 android {
-    compileSdkVersion 34
+    compileSdkVersion 35
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
@@ -20,10 +20,10 @@ android {
     defaultConfig {
         applicationId "com.thejiltedalchemist.lunchroulette"
         minSdkVersion 26
-        targetSdkVersion 34
+        targetSdkVersion 35
         versionCode 1
         versionName "1.0"
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildFeatures {
         viewBinding = true
@@ -31,22 +31,22 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     namespace 'com.thejiltedalchemist.lunchroulette'
 }
 
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation"org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.android.support:appcompat-v7:28.0.0'
-    implementation 'com.android.support.constraint:constraint-layout:2.0.4'
-    implementation 'com.android.support:recyclerview-v7:28.0.0'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation 'androidx.appcompat:appcompat:1.7.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
+    implementation 'androidx.recyclerview:recyclerview:1.3.2'
     implementation 'com.google.android.material:material:1.12.0'
     testImplementation 'junit:junit:4.13.2'
-    testImplementation 'org.mockito:mockito-core:2.25.0' //unit tests
-    androidTestImplementation 'org.mockito:mockito-android:2.25.0'
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+    testImplementation 'org.mockito:mockito-core:5.14.2'
+    androidTestImplementation 'org.mockito:mockito-android:5.14.2'
+    androidTestImplementation 'androidx.test:runner:1.6.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.2.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,16 +6,16 @@ apply plugin: 'kotlin-parcelize'
 android {
     compileSdkVersion 35
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
     }
     java {
         toolchain {
-            languageVersion.set(JavaLanguageVersion.of(17))
+            languageVersion.set(JavaLanguageVersion.of(21))
         }
     }
     kotlinOptions {
-        jvmTarget = '17'
+        jvmTarget = '21'
     }
     defaultConfig {
         applicationId "com.thejiltedalchemist.lunchroulette"

--- a/app/src/androidTest/java/com/thejiltedalchemist/lunchroulette/ExampleInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/thejiltedalchemist/lunchroulette/ExampleInstrumentedTest.kt
@@ -1,24 +1,18 @@
 package com.thejiltedalchemist.lunchroulette
 
-import android.support.test.InstrumentationRegistry
-import android.support.test.runner.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.ext.junit.runners.AndroidJUnit4
 
 import org.junit.Test
 import org.junit.runner.RunWith
 
 import org.junit.Assert.*
 
-/**
- * Instrumented test, which will execute on an Android device.
- *
- * See [testing documentation](http://d.android.com/tools/testing).
- */
 @RunWith(AndroidJUnit4::class)
 class ExampleInstrumentedTest {
     @Test
     fun useAppContext() {
-        // Context of the app under test.
-        val appContext = InstrumentationRegistry.getTargetContext()
+        val appContext = InstrumentationRegistry.getInstrumentation().targetContext
         assertEquals("com.thejiltedalchemist.lunchroulette", appContext.packageName)
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.9.23'
+    ext.kotlin_version = '2.1.0'
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.4.1'
+        classpath 'com.android.tools.build:gradle:8.7.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Intermediate step: bumped Gradle 8.6→8.11.1, Kotlin 1.9→2.1, AGP 8.4→8.7, compileSdk 34→35. Superseded by chore/update-sdk and chore/migrate-build-scripts.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CMSARgRyKBg1wrtrfoVNcc)_