### PR TITLE
Fix center circle offset on roulette wheel

### DIFF
--- a/app/src/main/java/com/thejiltedalchemist/lunchroulette/RouletteView.kt
+++ b/app/src/main/java/com/thejiltedalchemist/lunchroulette/RouletteView.kt
@@ -119,8 +119,10 @@ class RouletteView(context: Context,attrs: AttributeSet) : View(context, attrs) 
         centerPaint.setColor(colorLight)
         center2Paint.setColor(colorDark)
         centerPaintOutline.setColor(textColor)
-        canvas.drawCircle(radius/2, radius/2, radius/11f, centerPaintOutline)
-        canvas.drawCircle(radius/2, radius/2, radius/12f, centerPaint)
-        canvas.drawCircle(radius/2, radius/2, radius/16f, center2Paint)
+        val cx = padding + radius / 2
+        val cy = padding + radius / 2
+        canvas.drawCircle(cx, cy, radius/11f, centerPaintOutline)
+        canvas.drawCircle(cx, cy, radius/12f, centerPaint)
+        canvas.drawCircle(cx, cy, radius/16f, center2Paint)
     }
 }


### PR DESCRIPTION
## Summary
- `drawCenter()` was drawing the hub circles at `(radius/2, radius/2)`, but the arc bounding rect starts at `(padding, padding)`, so the true wheel center is `(padding + radius/2, padding + radius/2)`
- All three `drawCircle` calls now use the correct `cx`/`cy` values, placing the hub precisely at the wheel's geometric center

## Test plan
- [ ] Launch the app and spin the wheel — the center hub should sit exactly in the middle of the pie slices
- [ ] Verify the hub is still visible and correctly layered over the slice edges

---
_Generated by [Claude Code](https://claude.ai/code/session_01CMSARgRyKBg1wrtrfoVNcc)_