### PR TITLE
Add haptic feedback on spin start and winner reveal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,3 +47,14 @@ Single-module Android app (Kotlin, minSdk 26, targetSdk 34) with two activities 
 
 - `onUpgrade` in `RestaurantsDBHelper` calls `onCreate` without dropping the old table — increment `DATABASE_VERSION` when changing the schema and add a proper migration.
 - The `address` column exists in the DB schema but is never populated or read.
+
+## Feature Backlog
+
+| Branch | Work |
+|---|---|
+| `feature/winner-celebration` | Confetti animation + winner popup dialog on spin finish; highlight/pulse the winning wedge in `RouletteView` |
+| `feature/shake-to-spin` | Accelerometer-triggered spin via `SensorManager` |
+| `feature/spin-history` | SQLite table + UI for last N winners (name + timestamp) |
+| `feature/share-result` | Share winner via `Intent.ACTION_SEND` |
+| `chore/readme-and-goal` | Add `README.md` with goal statement and build instructions |
+| `chore/replace-icons` | Replace `dd_logo.png` (DoorDash asset) and Android launcher icon placeholder |

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <uses-permission android:name="android.permission.VIBRATE" />
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"

--- a/app/src/main/java/com/thejiltedalchemist/lunchroulette/MainActivity.kt
+++ b/app/src/main/java/com/thejiltedalchemist/lunchroulette/MainActivity.kt
@@ -1,8 +1,11 @@
 package com.thejiltedalchemist.lunchroulette
 
+import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.os.CountDownTimer
+import android.os.VibrationEffect
+import android.os.Vibrator
 import android.view.View
 import android.view.animation.OvershootInterpolator
 import android.widget.Button
@@ -22,10 +25,12 @@ class MainActivity : AppCompatActivity() {
     private val foodList = arrayListOf<String>()
     private lateinit var activityMainBinding: ActivityMainBinding
     private lateinit var restaurantsDBHelper : RestaurantsDBHelper
+    private lateinit var vibrator: Vibrator
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         restaurantsDBHelper = RestaurantsDBHelper(this)
+        vibrator = getSystemService(Context.VIBRATOR_SERVICE) as Vibrator
         activityMainBinding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(activityMainBinding.root)
 
@@ -58,6 +63,7 @@ class MainActivity : AppCompatActivity() {
 
             button.isEnabled = false
             activityMainBinding.selectedFoodText.text = getString(R.string.default_selection)
+            vibrator.vibrate(VibrationEffect.createOneShot(40, VibrationEffect.DEFAULT_AMPLITUDE))
 
             // Pointer sits at 12 o'clock (270° in canvas arc coordinates).
             // Rotating the view by finalRotation places the centre of slice spinIndex at 270°.
@@ -84,6 +90,9 @@ class MainActivity : AppCompatActivity() {
                     ivWheel.rotation = finalRotation
                     button.isEnabled = true
                     activityMainBinding.selectedFoodText.text = winner
+                    vibrator.vibrate(VibrationEffect.createWaveform(
+                        longArrayOf(0, 80, 60, 120), -1
+                    ))
                 }
             }.start()
         }


### PR DESCRIPTION
## Summary
- Adds `VIBRATE` permission to `AndroidManifest.xml`
- Short 40ms buzz fires when the spin button is pressed (spin start)
- Double-pulse pattern (80ms + 120ms with 60ms gap) fires in `onFinish()` when the winner is revealed
- Uses `VibrationEffect` API (minSdk 26, no compat shim needed)
- Adds feature backlog to `CLAUDE.md` including the upcoming `feature/winner-celebration` item

## Test plan
- [ ] Tap Spin — feel a short buzz immediately
- [ ] Wait for wheel to stop — feel a double-pulse on winner reveal
- [ ] Verify no crash if device has no vibrator (gracefully no-ops)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CMSARgRyKBg1wrtrfoVNcc)_