### PR TITLE
Fix kotlinOptions removed in AGP 9.x

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,16 +3,13 @@ plugins {
     alias(libs.plugins.kotlin.parcelize)
 }
 
+kotlin {
+    jvmToolchain(17)
+}
+
 android {
     compileSdk = 36
     namespace = "com.thejiltedalchemist.lunchroulette"
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
-    }
-    kotlinOptions {
-        jvmTarget = "17"
-    }
     defaultConfig {
         applicationId = "com.thejiltedalchemist.lunchroulette"
         minSdk = 26


### PR DESCRIPTION
## Summary
- `kotlinOptions` was removed from the `android` block in AGP 9.0
- Replaces `kotlinOptions { jvmTarget = "17" }` and `compileOptions { ... }` with `kotlin { jvmToolchain(17) }` at the top level
- `jvmToolchain` is the modern single-declaration equivalent — it sets both the Kotlin JVM target and Java source/target compatibility together

---
_Generated by [Claude Code](https://claude.ai/code/session_01CMSARgRyKBg1wrtrfoVNcc)_