### PR TITLE
Replace jvmToolchain with explicit compiler targets

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,12 +4,18 @@ plugins {
 }
 
 kotlin {
-    jvmToolchain(17)
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+    }
 }
 
 android {
     compileSdk = 36
     namespace = "com.thejiltedalchemist.lunchroulette"
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
     defaultConfig {
         applicationId = "com.thejiltedalchemist.lunchroulette"
         minSdk = 26


### PR DESCRIPTION
## Summary
- `jvmToolchain(17)` triggers Gradle's Java Toolchain auto-detection, which fails if the matching JDK isn't discoverable on the host machine (e.g. Windows without a configured toolchain repository)
- Replaces it with `kotlin { compilerOptions { jvmTarget.set(JvmTarget.JVM_17) } }` + `compileOptions { sourceCompatibility/targetCompatibility }`, which set targets directly without invoking the toolchain system

---
_Generated by [Claude Code](https://claude.ai/code/session_01CMSARgRyKBg1wrtrfoVNcc)_