### PR TITLE
Remove deprecated gradle.properties flags

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,18 +1,3 @@
-## For more details on how to configure your build environment visit
-# http://www.gradle.org/docs/current/userguide/build_environment.html
-#
-# Specifies the JVM arguments used for the daemon process.
-# The setting is particularly useful for tweaking memory settings.
-# Default value: -Xmx1024m -XX:MaxPermSize=256m
-# org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
-#
-# When configured, Gradle will run in incubating parallel mode.
-# This option should only be used with decoupled projects. For more details, visit
-# https://developer.android.com/r/tools/gradle-multi-project-decoupled-projects
-# org.gradle.parallel=true
-#Wed May 15 02:46:29 PDT 2024
-android.enableJetifier=true
-android.nonFinalResIds=false
-android.nonTransitiveRClass=false
-android.useAndroidX=true
 org.gradle.jvmargs=-Xmx1536m
+android.useAndroidX=true
+android.nonTransitiveRClass=true


### PR DESCRIPTION
## Summary
- Remove `android.enableJetifier=true` — default is now `false`; the project uses AndroidX directly so Jetifier is not needed
- Remove `android.nonFinalResIds=false` — default is now `true`; no reason to override it
- Flip `android.nonTransitiveRClass` to `true` (modern default) — each module only sees its own R class
- Remove the stale timestamp comment and unused commented-out options

---
_Generated by [Claude Code](https://claude.ai/code/session_01CMSARgRyKBg1wrtrfoVNcc)_