### PR TITLE
Fix pointer deflecting against wheel spin direction

### DIFF
--- a/app/src/main/java/com/thejiltedalchemist/lunchroulette/MainActivity.kt
+++ b/app/src/main/java/com/thejiltedalchemist/lunchroulette/MainActivity.kt
@@ -104,7 +104,7 @@ class MainActivity : AppCompatActivity() {
         view.pivotX = view.width / 2f
         view.pivotY = 0f
         view.animate().cancel()
-        view.rotation = -18f
+        view.rotation = 18f
         view.animate()
             .rotation(0f)
             .setDuration(140)


### PR DESCRIPTION
Flips the initial rotation snap in `tickPointer()` from `-18f` to `18f` so the pointer tip swings in the same direction the wheel is travelling (counter-clockwise) instead of against it.

https://claude.ai/code/session_01CMSARgRyKBg1wrtrfoVNcc

---
_Generated by [Claude Code](https://claude.ai/code/session_01CMSARgRyKBg1wrtrfoVNcc)_