### PR TITLE
Add winner celebration: confetti, pulse highlight, and dialog

### DIFF
--- a/app/src/main/java/com/thejiltedalchemist/lunchroulette/ConfettiView.kt
+++ b/app/src/main/java/com/thejiltedalchemist/lunchroulette/ConfettiView.kt
@@ -1,0 +1,94 @@
+package com.thejiltedalchemist.lunchroulette
+
+import android.animation.ValueAnimator
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.util.AttributeSet
+import android.view.View
+import android.view.animation.LinearInterpolator
+import kotlin.math.PI
+import kotlin.math.cos
+import kotlin.math.sin
+import kotlin.random.Random
+
+class ConfettiView @JvmOverloads constructor(
+    context: Context, attrs: AttributeSet? = null
+) : View(context, attrs) {
+
+    private class Particle(
+        val startX: Float, val startY: Float,
+        val vx: Float, val vy: Float,
+        val color: Int, val size: Float,
+        val startRotation: Float, val rotSpeed: Float,
+        val isRect: Boolean
+    )
+
+    private val paint = Paint(Paint.ANTI_ALIAS_FLAG)
+    private var particles: List<Particle> = emptyList()
+    private var elapsed = 0f
+    private var animator: ValueAnimator? = null
+
+    private val palette = intArrayOf(
+        0xFFE74C3C.toInt(), 0xFFF39C12.toInt(), 0xFF2ECC71.toInt(),
+        0xFF3498DB.toInt(), 0xFF9B59B6.toInt(), 0xFFE91E8C.toInt(),
+        0xFF1ABC9C.toInt()
+    )
+
+    fun burst(cx: Float, cy: Float) {
+        animator?.cancel()
+        particles = List(80) {
+            val angle = (Random.nextFloat() * 2 * PI).toFloat()
+            val speed = Random.nextFloat() * 16f + 8f
+            Particle(
+                startX = cx, startY = cy,
+                vx = cos(angle) * speed,
+                vy = sin(angle) * speed - 22f,
+                color = palette[Random.nextInt(palette.size)],
+                size = Random.nextFloat() * 10f + 6f,
+                startRotation = Random.nextFloat() * 360f,
+                rotSpeed = (Random.nextFloat() - 0.5f) * 720f,
+                isRect = Random.nextBoolean()
+            )
+        }
+        elapsed = 0f
+        visibility = VISIBLE
+        animator = ValueAnimator.ofFloat(0f, 2.5f).apply {
+            duration = 2500
+            interpolator = LinearInterpolator()
+            addUpdateListener {
+                elapsed = it.animatedValue as Float
+                invalidate()
+            }
+            start()
+        }
+    }
+
+    override fun onDraw(canvas: Canvas) {
+        if (particles.isEmpty()) return
+        val gravity = 30f
+        val t = elapsed
+        val alpha = ((1f - t / 2.5f) * 255).toInt().coerceIn(0, 255)
+        if (alpha <= 0) {
+            visibility = GONE
+            particles = emptyList()
+            return
+        }
+        particles.forEach { p ->
+            val x = p.startX + p.vx * t
+            val y = p.startY + p.vy * t + 0.5f * gravity * t * t
+            val rot = p.startRotation + p.rotSpeed * t
+            paint.color = p.color
+            paint.alpha = alpha
+            canvas.save()
+            canvas.translate(x, y)
+            canvas.rotate(rot)
+            if (p.isRect) {
+                canvas.drawRect(-p.size / 2, -p.size / 4, p.size / 2, p.size / 4, paint)
+            } else {
+                canvas.drawCircle(0f, 0f, p.size / 2f, paint)
+            }
+            canvas.restore()
+        }
+    }
+}

--- a/app/src/main/java/com/thejiltedalchemist/lunchroulette/MainActivity.kt
+++ b/app/src/main/java/com/thejiltedalchemist/lunchroulette/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.thejiltedalchemist.lunchroulette
 
+import android.app.AlertDialog
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
@@ -63,6 +64,7 @@ class MainActivity : AppCompatActivity() {
 
             button.isEnabled = false
             activityMainBinding.selectedFoodText.text = getString(R.string.default_selection)
+            activityMainBinding.rouletteWheel.clearWinner()
             vibrator.vibrate(VibrationEffect.createOneShot(40, VibrationEffect.DEFAULT_AMPLITUDE))
 
             // Pointer sits at 12 o'clock (270° in canvas arc coordinates).
@@ -90,9 +92,23 @@ class MainActivity : AppCompatActivity() {
                     ivWheel.rotation = finalRotation
                     button.isEnabled = true
                     activityMainBinding.selectedFoodText.text = winner
-                    vibrator.vibrate(VibrationEffect.createWaveform(
-                        longArrayOf(0, 80, 60, 120), -1
-                    ))
+                    vibrator.vibrate(VibrationEffect.createWaveform(longArrayOf(0, 80, 60, 120), -1))
+                    activityMainBinding.rouletteWheel.setWinner(spinIndex)
+                    val wheelView = activityMainBinding.rouletteWheel
+                    activityMainBinding.confettiView.burst(
+                        wheelView.x + wheelView.width / 2f,
+                        wheelView.y + wheelView.height / 2f
+                    )
+                    activityMainBinding.root.postDelayed({
+                        if (!isFinishing && !isDestroyed) {
+                            AlertDialog.Builder(this@MainActivity)
+                                .setTitle("Today's lunch!")
+                                .setMessage(winner)
+                                .setPositiveButton("Let's go!") { d, _ -> d.dismiss() }
+                                .setCancelable(true)
+                                .show()
+                        }
+                    }, 500)
                 }
             }.start()
         }

--- a/app/src/main/java/com/thejiltedalchemist/lunchroulette/RouletteView.kt
+++ b/app/src/main/java/com/thejiltedalchemist/lunchroulette/RouletteView.kt
@@ -4,8 +4,10 @@
 
 package com.thejiltedalchemist.lunchroulette
 
+import android.animation.ValueAnimator
 import android.content.Context
 import android.graphics.Canvas
+import android.graphics.Color
 import android.graphics.Paint
 import android.graphics.Path
 import android.graphics.RectF
@@ -26,6 +28,9 @@ class RouletteView(context: Context,attrs: AttributeSet) : View(context, attrs) 
     private val textColor = resources.getColor(R.color.colorAccent)
     private val colorDark = resources.getColor(R.color.colorPrimaryDark)
     private val colorLight = resources.getColor(R.color.colorPrimary)
+
+    private var winnerIndex = -1
+    private var highlightAlpha = 0f
 
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
         super.onMeasure(widthMeasureSpec, heightMeasureSpec)
@@ -57,6 +62,12 @@ class RouletteView(context: Context,attrs: AttributeSet) : View(context, attrs) 
             canvas.drawArc(rectangle, index * arcAngle, arcAngle, true, arcPaint)
             writeText(canvas, index * arcAngle, arcAngle, item.name)
         }
+        if (winnerIndex >= 0) {
+            arcPaint.color = Color.WHITE
+            arcPaint.alpha = (highlightAlpha * 120).toInt()
+            canvas.drawArc(rectangle, winnerIndex * arcAngle, arcAngle, true, arcPaint)
+            arcPaint.alpha = 255
+        }
         drawCenter(canvas)
     }
 
@@ -81,6 +92,26 @@ class RouletteView(context: Context,attrs: AttributeSet) : View(context, attrs) 
      */
     fun addRouletteItems(items: List<RestaurantsModel>) {
         itemList = items
+        invalidate()
+    }
+
+    fun setWinner(index: Int) {
+        winnerIndex = index
+        ValueAnimator.ofFloat(0f, 1f).apply {
+            duration = 600
+            repeatMode = ValueAnimator.REVERSE
+            repeatCount = 5
+            addUpdateListener {
+                highlightAlpha = it.animatedValue as Float
+                invalidate()
+            }
+            start()
+        }
+    }
+
+    fun clearWinner() {
+        winnerIndex = -1
+        highlightAlpha = 0f
         invalidate()
     }
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -84,4 +84,16 @@
         app:layout_constraintTop_toBottomOf="@+id/listFoodsButton"
         app:layout_constraintVertical_bias="1.0" />
 
+    <com.thejiltedalchemist.lunchroulette.ConfettiView
+        android:id="@+id/confettiView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:clickable="false"
+        android:importantForAccessibility="no"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## Summary
- **Winning wedge pulse** — `RouletteView.setWinner(index)` starts a `ValueAnimator` that draws a white overlay on the winning slice, pulsing 6 times over ~6s; `clearWinner()` resets it at the start of each spin
- **Confetti burst** — new `ConfettiView` draws 80 particles (mix of rects and circles) launched from the wheel centre with physics (initial upward velocity + gravity) and alpha fade over 2.5s; passes touches through via `clickable=false`
- **Winner dialog** — `AlertDialog` with the winner name appears 500ms after the wheel settles, giving the confetti a moment to start

## Test plan
- [ ] Spin the wheel — confetti bursts from wheel centre on finish
- [ ] Winning wedge pulses white a few times
- [ ] Dialog appears with the correct winner name ~500ms after stop
- [ ] Tapping "Let's go!" dismisses the dialog
- [ ] Spinning again clears the previous highlight before the new spin starts

---
_Generated by [Claude Code](https://claude.ai/code/session_01CMSARgRyKBg1wrtrfoVNcc)_